### PR TITLE
Fix divide by zero in exponential backoff minimum interval

### DIFF
--- a/backoff.go
+++ b/backoff.go
@@ -103,6 +103,12 @@ func (b *linearBackoff) Clone() Backoff {
 //
 //     `min(MaxInterval, base +/- (base * RandFactor))`.
 func NewExponentialBackoff(minInterval, maxInterval time.Duration, configs ...ExponentialConfigFunc) Backoff {
+	if minInterval == 0 {
+		// To avoid a divide by zero we set the minimum interval to something
+		// that makes sense.
+		minInterval = 1
+	}
+
 	backoff := &exponentialBackoff{
 		minInterval: minInterval,
 		maxInterval: maxInterval,

--- a/backoff_test.go
+++ b/backoff_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/aphistic/sweet"
-	"github.com/aphistic/sweet-junit"
+	junit "github.com/aphistic/sweet-junit"
 	. "github.com/onsi/gomega"
 )
 
@@ -53,6 +53,12 @@ func (s *BackoffSuite) TestNonRandom(t sweet.T) {
 	testSequence(b, time.Millisecond, []uint{1, 2, 4, 8, 16, 32})
 	b.Reset()
 	testSequence(b, time.Millisecond, []uint{1, 2, 4, 8, 16, 32})
+}
+
+func (s *BackoffSuite) TestZeroTimeMinimum(t sweet.T) {
+	Expect(func() {
+		NewExponentialBackoff(0*time.Millisecond, time.Millisecond*4)
+	}).ToNot(Panic())
 }
 
 func (s *BackoffSuite) TestMax(t sweet.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/efritz/backoff
 
+go 1.12
+
 require (
 	github.com/aphistic/sweet v0.0.0-20180618201346-68e18ab55a67
 	github.com/aphistic/sweet-junit v0.0.0-20171005212431-6b78f7014f7c


### PR DESCRIPTION
Small update to avoid a divide by zero. I'd understand if you don't want to merge this because it does make a transparent change in functionality to what the user passed in, but I think it's functionally negligible.

My Go version (1.15) wanted to add a `go 1.15` to the `go.mod` but I set it back to 1.12 so it doesn't try that again but still won't cause any issues with Go versions between them.